### PR TITLE
Metadata form

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,7 @@ module.exports = function(config) {
           console.log(err);
         }
       });
+
       // Error handler for malformed JSON
       router.use((err, req, res, next) => {
         if (err instanceof SyntaxError) {
@@ -300,50 +301,10 @@ module.exports = function(config) {
 
         // Load the request cache
         router.formio.cache = require('./src/cache/cache')(router);
+
         // return the form metadata
-
-        router.get('/form/:formId/metadata',function(req,res,next) {
-          router.formio.resources.form.model.findOne({_id: req.params.formId}, function(err, form) {
-            if (err) {
-              return next(err);
-            }
-
-            if (!form) {
-              return res.status(404).send('Form not found');
-            }
-            const ignoredTypes = ["button"];
-            const result = [];
-            util.eachComponent(form.components,(com,path)=>{
-              const data = {
-                name:com.key,
-                label:com.label,
-                type: com.type
-              };
-              let parentObject = null;
-              if (path.includes(".")) {
-                  const pathsArray =  _.initial(path.split("."));
-                  for (const singleKey of pathsArray) {
-                    if (!parentObject) {
-                      parentObject = result.find(i=> i.name === singleKey);
-                    }
-                    else {
-                      parentObject = parentObject.components.find(i=> i.name === singleKey);
-                    }
-                    if (!parentObject.components) {
-                      parentObject.components = [];
-                    }
-                    parentObject.components.push(data);
-                  }
-              }
-            else {
-                if (!ignoredTypes.includes(com.type)) {
-                  result.push(data);
-                }
-              }
-            });
-            res.json(result);
-          });
-        });
+        const metadataResource = require('./src/resources/formMetadata');
+        router.get('/form/:formId/metadata',metadataResource.getFormMetadata(router));
 
         // Return the form components.
         router.get('/form/:formId/components', function(req, res, next) {

--- a/src/resources/formMetadata.js
+++ b/src/resources/formMetadata.js
@@ -1,0 +1,82 @@
+const Utils = require("../util/util");
+const _ = require("lodash");
+module.exports = {
+  getFormMetadata: (router) =>
+    async function (req, res, next) {
+      try {
+        const { formIds, isBundle } = req.query;
+        const ids =
+          formIds && isBundle ? formIds.split(",") : [req.params.formId];
+        const isTheFormIdIsBundle = isBundle == "true";
+        if (isTheFormIdIsBundle) {
+          const bundleData = await router.formio.resources.form.model.findOne({
+            _id: req.params.formId,
+          });
+          if (!bundleData || !bundleData.isBundle) {
+            return res.status(404).send({ error: "Bundle not found" });
+          } else if (!formIds?.length) {
+            return res
+              .status(400)
+              .send({ error: "formIds not find in query string" });
+          }
+        }
+        router.formio.resources.form.model.find(
+          { _id: { $in: ids } },
+          function (err, forms) {
+            if (err) {
+              return next(err);
+            }
+            if (!forms.length) {
+              return res.status(404).send("Form not found");
+            }
+            const ignoredTypes = ["button"];
+            const addedPaths = [];
+            const metadata = [];
+            for (const form of forms) {
+              Utils.eachComponent(form.components, (com, path) => {
+                const data = {
+                  name: com.key,
+                  label: com.label,
+                  type: com.type,
+                };
+                let parentObject = null;
+                if (path.includes(".")) {
+                  const pathsArray = _.initial(path.split("."));
+                  for (const singleKey of pathsArray) {
+                    if (!parentObject) {
+                      parentObject = metadata.find((i) => i.name === singleKey);
+                    } else {
+                      parentObject = parentObject.components.find(
+                        (i) => i.name === singleKey
+                      );
+                    }
+                    if (!parentObject.components) {
+                      parentObject.components = [];
+                    }
+                    if (
+                      !ignoredTypes.includes(com.type) &&
+                      !addedPaths.includes(path)
+                    ) {
+                      parentObject.components.push(data);
+                    }
+                  }
+                } else {
+                  if (
+                    !ignoredTypes.includes(com.type) &&
+                    !addedPaths.includes(path)
+                  ) {
+                    metadata.push(data);
+                  }
+                }
+                addedPaths.push(path);
+              });
+            }
+
+            res.json(metadata);
+          }
+        );
+      } catch (error) {
+        next(error);
+      }
+    },
+};

--- a/src/resources/formMetadata.js
+++ b/src/resources/formMetadata.js
@@ -5,9 +5,10 @@ module.exports = {
     async function (req, res, next) {
       try {
         const { formIds, isBundle } = req.query;
-        const ids =
-          formIds && isBundle ? formIds.split(",") : [req.params.formId];
         const isTheFormIdIsBundle = isBundle == "true";
+        const ids =
+          formIds && isTheFormIdIsBundle ? formIds.split(",") : [req.params.formId];
+
         if (isTheFormIdIsBundle) {
           const bundleData = await router.formio.resources.form.model.findOne({
             _id: req.params.formId,


### PR DESCRIPTION
# Pull Request: Feature - Form Metadata Endpoint

## Changes Made

- Added a new endpoint `/form/formid/metadata` to retrieve form metadata.
- If `isBundle=true` and `formIds` are provided as a comma-separated list (e.g., `formid1,formid2`), the endpoint will return bundle metadata.

## Description

This pull request introduces a new API endpoint to retrieve form metadata. The endpoint is accessible at `/form/formid/metadata`. By default, it returns metadata for a single form with the specified `formid`. Additionally, when the query parameter `isBundle` is set to `true` and `formIds` are provided, the endpoint will return metadata for a bundle of forms.

### Example Usage

#### Single Form Metadata
```http
GET /form/formid/metadata
GET /form/formid/metadata?isBundle=true&formIds=121,1212,1212
